### PR TITLE
Adding image URLs in export file

### DIFF
--- a/visualization/js/viewData.js
+++ b/visualization/js/viewData.js
@@ -82,7 +82,18 @@ $(document).ready(function () {
         lengthMenu: [[20, 50, 100, -1], [20, 50, 100, 'All']],
         dom: 'Blfrtip',
         buttons: [
-          'csv', 'excel'
+          {
+            extend: "csv",
+            exportOptions: {
+              stripHtml: false
+            }
+          },
+          {
+            extend: "excel",
+            exportOptions: {
+              stripHtml: false
+            }
+          },
         ]
       })
     }, function (err) {


### PR DESCRIPTION
-Setting strip HTML to false so that handshape image urls are included in the export file